### PR TITLE
Feature/18511 melhorias cadastro infantil

### DIFF
--- a/src/helpers/helpers.js
+++ b/src/helpers/helpers.js
@@ -79,3 +79,7 @@ export const agregarDefault = lista => {
 export const deepCopy = obj => {
   return JSON.parse(JSON.stringify(obj));
 };
+
+export const between = (x, min, max) => {
+  return x >= min && x <= max;
+}

--- a/src/helpers/validators.js
+++ b/src/helpers/validators.js
@@ -16,6 +16,11 @@ export const apenasUmEspaco = (value) =>
     ? `Não permite mais de um espaço em branco seguidos`
     : undefined;
 
+export const semLetraSolta = (value) =>
+  value && /(\s(?![E])[A-Z]\s|^(?![E])[A-Z]\s|\s(?![E])[A-Z]$)/g.test(value)
+    ? `Não permite letra solta`
+    : undefined;
+
 export const somenteCaracteresEEspacos = (value) =>
   value && !/^[a-zA-Z çÇ]+$/i.test(value)
     ? `Somente caracteres sem acento, cedilha e espaços`
@@ -55,3 +60,4 @@ export const somenteAlfanumericos = (value) =>
   value && /[^a-zA-Z0-9 ]/i.test(value)
     ? "Somente caracteres alfanuméricos"
     : undefined;
+

--- a/src/helpers/validators.js
+++ b/src/helpers/validators.js
@@ -1,4 +1,4 @@
-import { validarCPF } from "./helpers";
+import { validarCPF, between } from "./helpers";
 
 export const composeValidators = (...validators) => (value) =>
   validators.reduce((error, validator) => error || validator(value), undefined);
@@ -24,6 +24,13 @@ export const somenteCaracteresEEspacos = (value) =>
 export const validaCEP = (value) => {
   let numero = value.replace("-", "").replace(/_/g, "");
   return numero.length === 8 ? undefined : "Necessário CEP válido!";
+};
+
+export const validaRangeCEP = (value) => {
+  let numero = value.replace("-", "").replace(/_/g, "");
+  return (between(numero, 1000000, 5999999)||between(numero, 8000000, 8499999))
+  ? undefined
+  : "Necessário CEP da cidade de São Paulo!";
 };
 
 export const validaCPF = (value) => {

--- a/src/helpers/validators.js
+++ b/src/helpers/validators.js
@@ -11,6 +11,11 @@ export const semCaracteresEspeciais = (value) =>
     ? `Não permite caracteres especiais`
     : undefined;
 
+export const apenasUmEspaco = (value) =>
+  value && /^.*\s{2,}.*$/.test(value)
+    ? `Não permite mais de um espaço em branco seguidos`
+    : undefined;
+
 export const somenteCaracteresEEspacos = (value) =>
   value && !/^[a-zA-Z çÇ]+$/i.test(value)
     ? `Somente caracteres sem acento, cedilha e espaços`

--- a/src/screens/Formulario/index.jsx
+++ b/src/screens/Formulario/index.jsx
@@ -11,6 +11,7 @@ import {
   required,
   somenteCaracteresEEspacos,
   validaCEP,
+  validaRangeCEP,
   validaCPF,
   validaEmail,
   validaTelefoneOuCelular,
@@ -248,7 +249,7 @@ export const Formulario = () => {
                       label="CEP da criança"
                       name="cep_moradia"
                       required
-                      validate={composeValidators(required, validaCEP)}
+                      validate={composeValidators(required, validaCEP, validaRangeCEP)}
                       placeholder="Digite o CEP"
                     />
                     <OnChange name="cep_moradia">

--- a/src/screens/Formulario/index.jsx
+++ b/src/screens/Formulario/index.jsx
@@ -426,6 +426,18 @@ export const Formulario = () => {
                         values.nome_responsavel = values.filiacao2_consta
                           ? null
                           : values.nome_responsavel;
+                        values.filiacao2_nome = values.filiacao2_consta
+                          ? null
+                          : values.filiacao2_nome;
+                        values.filiacao2_falecido = values.filiacao2_consta
+                          ? null
+                          : values.filiacao2_falecido;
+                        values.filiacao2_sexo = values.filiacao2_consta
+                          ? null
+                          : values.filiacao2_sexo;
+                        values.filiacao2_nacionalidade = values.filiacao2_consta
+                          ? "Brasil"
+                          : values.filiacao2_nacionalidade;
                       }}
                     />{" "}
                     consta na certidão

--- a/src/screens/Formulario/index.jsx
+++ b/src/screens/Formulario/index.jsx
@@ -390,7 +390,7 @@ export const Formulario = () => {
                   <div className="col-sm-5 col-12">
                     <RadioButtonSexo
                       name="filiacao1_sexo"
-                      label="Sexo"
+                      label="Sexo Filiação 1"
                       required
                     />
                   </div>
@@ -461,7 +461,7 @@ export const Formulario = () => {
                       <div className="col-sm-5 col-12">
                         <RadioButtonSexo
                           name="filiacao2_sexo"
-                          label="Sexo"
+                          label="Sexo Filiação 2"
                           required
                         />
                       </div>

--- a/src/screens/Formulario/index.jsx
+++ b/src/screens/Formulario/index.jsx
@@ -15,6 +15,7 @@ import {
   validaEmail,
   validaTelefoneOuCelular,
   somenteAlfanumericos,
+  apenasUmEspaco,
 } from "../../helpers/validators";
 import Select from "../../components/Select";
 import { NACIONALIDADES } from "../../constants/NACIONALIDADES";
@@ -105,7 +106,8 @@ export const Formulario = () => {
                   toUppercaseActive
                   validate={composeValidators(
                     required,
-                    somenteCaracteresEEspacos
+                    somenteCaracteresEEspacos,
+                    apenasUmEspaco
                   )}
                 />
                 <div className="row mt-2">

--- a/src/screens/Formulario/index.jsx
+++ b/src/screens/Formulario/index.jsx
@@ -17,6 +17,7 @@ import {
   validaTelefoneOuCelular,
   somenteAlfanumericos,
   apenasUmEspaco,
+  semLetraSolta,
 } from "../../helpers/validators";
 import Select from "../../components/Select";
 import { NACIONALIDADES } from "../../constants/NACIONALIDADES";
@@ -108,7 +109,8 @@ export const Formulario = () => {
                   validate={composeValidators(
                     required,
                     somenteCaracteresEEspacos,
-                    apenasUmEspaco
+                    apenasUmEspaco,
+                    semLetraSolta
                   )}
                 />
                 <div className="row mt-2">
@@ -693,3 +695,4 @@ export const Formulario = () => {
 };
 
 export default Formulario;
+


### PR DESCRIPTION
Esse PR:

- Altera label sexo de filiação1;
- Altera label sexo de filiação2;
- Adiciona validação para dois ou mais espaços em branco;
- Valida Range de CEP`s permitidos;
- Valida letras soltas;
- Ao desmarcar a flag Consta na certidão, limpa os dados informados nos campos Nome completo, falecido? e Sexo;